### PR TITLE
Unregister ActivityLifecycleCallbacks

### DIFF
--- a/android/src/main/kotlin/io/intheloup/beacons/BeaconsPlugin.kt
+++ b/android/src/main/kotlin/io/intheloup/beacons/BeaconsPlugin.kt
@@ -34,6 +34,7 @@ class BeaconsPlugin(val registrar: Registrar) {
             override fun onActivityDestroyed(activity: Activity) {
                 beaconClient.unbind()
                 permissionClient.unbind()
+                activity.application.unregisterActivityLifecycleCallbacks(this)
             }
 
             override fun onActivityResumed(activity: Activity?) {


### PR DESCRIPTION
Any time the FlutterActivity registers for this plugin, the plugin itself registers to the ActivityLifecycleCallbacks. This is a problem because, if you close the FlutterActivity but not the application (by using the hardware back button, for instance), when you restart the activity, it registers again, causing a crash on the first onPause call.
Since Flutter only uses one FlutterActivity, it's safe to unregister for the ActivityLifecycleCallbacks when it gets destroyed.

Steps to reproduce the problem:
- Create app using this plugin and open it once
- Close the application by pushing the back button of your device
- Reopen the application
- Try to go back to your device home by using the back or home button -> CRASH.