### PR TITLE
Bugfixes on Android iBeacon monitoring

### DIFF
--- a/android/src/main/kotlin/io/intheloup/beacons/BeaconsPlugin.kt
+++ b/android/src/main/kotlin/io/intheloup/beacons/BeaconsPlugin.kt
@@ -32,7 +32,7 @@ class BeaconsPlugin(val registrar: Registrar) {
             }
 
             override fun onActivityDestroyed(activity: Activity) {
-                beaconClient.unbind()
+                // beaconClient.unbind()
                 permissionClient.unbind()
             }
 

--- a/lib/data/beacon_region.dart
+++ b/lib/data/beacon_region.dart
@@ -19,8 +19,8 @@ class BeaconRegionIBeacon extends BeaconRegion {
   BeaconRegionIBeacon({
     @required String identifier,
     @required String proximityUUID,
-    int major,
-    int minor,
+    String major,
+    String minor,
   }) : super(
           identifier: identifier,
           ids: [],
@@ -44,7 +44,7 @@ class BeaconRegionIBeacon extends BeaconRegion {
 
   String get proximityUUID => ids[0];
 
-  int get major => ids.length > 1 ? ids[1] : null;
+  String get major => ids.length > 1 ? ids[1] : null;
 
-  int get minor => ids.length > 2 ? ids[2] : null;
+  String get minor => ids.length > 2 ? ids[2] : null;
 }


### PR DESCRIPTION
Changed beacon major and minor ids to String in BeaconRegionIBeacon to prevent parsing errors, removed unbind function