### PR TITLE
Fixed compilation errors on latest Flutter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'io.intheloup.beacons'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.2.41'
+    ext.kotlin_version = '1.2.51'
     repositories {
         google()
         jcenter()
@@ -50,7 +50,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.22.5"
 
     implementation "com.android.support:support-compat:27.1.1"
-    implementation "com.android.support:support-core-utils:27.1.1"
+    implementation "com.android.support:support-core-utils:26.1.0"
     implementation "org.altbeacon:android-beacon-library:2.14"
     implementation "com.squareup.moshi:moshi:1.5.0"
 


### PR DESCRIPTION
 Updated kotlin version + downgraded android core utils to suppress compilation issues on projects generated with the latest version of Flutter (v1.0.0 / Dart 2.1.0)